### PR TITLE
Add a way to configure Executable Reporter.

### DIFF
--- a/collector/controller_options.go
+++ b/collector/controller_options.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector // import "go.opentelemetry.io/ebpf-profiler/collector"
+
+import (
+	"go.opentelemetry.io/ebpf-profiler/reporter"
+)
+
+type option interface {
+	Apply(*controllerOption) *controllerOption
+}
+
+type controllerOption struct {
+	executableReporter reporter.ExecutableReporter
+}
+
+type optFunc func(*controllerOption) *controllerOption
+
+func (f optFunc) Apply(c *controllerOption) *controllerOption { return f(c) }
+
+// WithExecutableReporter is a function that allows to configure a ExecutableReporter.
+func WithExecutableReporter(executableReporter reporter.ExecutableReporter) option {
+	return optFunc(func(option *controllerOption) *controllerOption {
+		option.executableReporter = executableReporter
+		return option
+	})
+}

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -32,13 +32,27 @@ func NewFactory() receiver.Factory {
 }
 
 func createProfilesReceiver(
-	_ context.Context,
+	ctx context.Context,
 	rs receiver.Settings,
 	baseCfg component.Config,
 	nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
+	return BuildProfilesReceiver(ctx, rs, baseCfg, nextConsumer)
+}
+
+func BuildProfilesReceiver(
+	ctx context.Context,
+	rs receiver.Settings,
+	baseCfg component.Config,
+	nextConsumer xconsumer.Profiles,
+	options ...option) (xreceiver.Profiles, error) {
 	cfg, ok := baseCfg.(*Config)
 	if !ok {
 		return nil, errInvalidConfig
+	}
+
+	controllerOption := &controllerOption{}
+	for _, option := range options {
+		option.Apply(controllerOption)
 	}
 
 	controlerCfg := &controller.Config{
@@ -53,6 +67,7 @@ func createProfilesReceiver(
 		VerboseMode:            cfg.VerboseMode,
 		OffCPUThreshold:        cfg.OffCPUThreshold,
 		IncludeEnvVars:         cfg.IncludeEnvVars,
+		ExecutableReporter:     controllerOption.executableReporter,
 	}
 
 	return internal.NewController(controlerCfg, rs, nextConsumer)

--- a/collector/factory_test.go
+++ b/collector/factory_test.go
@@ -37,7 +37,7 @@ func TestCreateProfilesReceiver(t *testing.T) {
 			t.Parallel()
 			typ, err := component.NewType("ProfilesReceiver")
 			require.NoError(t, err)
-			_, err = createProfilesReceiver(
+			_, err = BuildProfilesReceiver(
 				t.Context(),
 				receivertest.NewNopSettings(typ),
 				tt.config,

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -35,7 +35,8 @@ type Config struct {
 	UProbeLinks            []string
 	LoadProbe              bool
 
-	Reporter reporter.Reporter
+	Reporter           reporter.Reporter
+	ExecutableReporter reporter.ExecutableReporter
 
 	Fs *flag.FlagSet
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -99,6 +99,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		IncludeEnvVars:         envVars,
 		UProbeLinks:            c.config.UProbeLinks,
 		LoadProbe:              c.config.LoadProbe,
+		ExecutableReporter:     c.config.ExecutableReporter,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to load eBPF tracer: %w", err)


### PR DESCRIPTION
## Description

This PR allows to set a custom Executable Reporter.

See this [document](https://docs.google.com/document/d/1QGRCABBgA-eJ3BXe0k0oM6MNGdVXvHmgDT675KxCVZo/edit?tab=t.0#heading=h.f2fxlsoa2dqh) for additional requirements.

This PR is part of a serie of PRs that replaces https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/811

Note: It is built on top of https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/825.

## Example of usage

```go
var (
	typeStr = component.MustNewType("profiling")
)

// NewFactory creates a factory for the receiver.
func NewFactory() receiver.Factory {
	return xreceiver.NewFactory(
		typeStr,
		defaultConfig,
		xreceiver.WithProfiles(createProfilesReceiver, component.StabilityLevelAlpha))
}

func createProfilesReceiver(
	ctx context.Context,
	rs receiver.Settings,
	baseCfg component.Config,
	nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
	config, ok := baseCfg.(Config)
	if !ok {
		return nil, errors.New("invalid config type")
	}
	
	executableReporter := &MyExecutableReporter{
		Settings: config.ExecutableReporterSettings,
	}

	return ebpfcollector.BuildProfilesReceiver(
		ctx,
		rs,
		config.Config,
		nextConsumer,
		ebpfcollector.WithExecutableReporter(executableReporter),
	)
}

// Executable Reporter
type MyExecutableReporter struct {
	Settings string
}

func (m *MyExecutableReporter) ReportExecutable(args *reporter.ExecutableMetadata) {
	fmt.Println("ReportExecutable", args)
}


// Config
type Config struct {
	*ebpfcollector.Config      `mapstructure:",squash"`
	ExecutableReporterSettings string `mapstructure:"executable_reporter_settings"`

}

func defaultConfig() component.Config {
	cfg := ebpfcollector.NewFactory().CreateDefaultConfig().(*ebpfcollector.Config)

	return Config{
		Config:                     cfg,
		ExecutableReporterSettings: "executable_reporter_settings",
	}
}
```